### PR TITLE
fix the dollar operator for 03a

### DIFF
--- a/resources/dnamage/dnamage.R
+++ b/resources/dnamage/dnamage.R
@@ -355,7 +355,7 @@ main <- function()
   
   message("Predicting, adjusting and standardizing DunedinPACE")########################################
   PredAgeDun <- try(PACEProjector(norm.beta, proportionOfProbesRequired=0.7), silent = TRUE)
-  paceresult <- data.frame("IID" = names(PredAgeDun$DunedinPACE), "PredAge" = PredAgeDun$DunedinPACE)
+  paceresult <- data.frame("IID" = names(PredAgeDun[['DunedinPACE']]), "PredAge" = PredAgeDun[['DunedinPACE']])
   
   if (inherits(paceresult, 'data.frame') & inherits(paceresult$PredAge, 'numeric')) {
     pacepred <- paceresult


### PR DESCRIPTION
This pull request fix the bug for #14 where the `$` extraction results in an error for some users.
This is not an breaking change.

The original code is in line 358 dnamage.R
```
paceresult <- data.frame("IID" = names(PredAgeDun$DunedinPACE), "PredAge" = PredAgeDun$DunedinPACE)
```

The new code is in line 358 in dnamage.R
```
paceresult <- data.frame("IID" = names(PredAgeDun[['DunedinPACE']]), "PredAge" = PredAgeDun[['DunedinPACE']])

```
