### PR TITLE
unmute the error message for the PACEprojector 

### DIFF
--- a/resources/dnamage/dnamage.R
+++ b/resources/dnamage/dnamage.R
@@ -354,7 +354,7 @@ main <- function()
   
   
   message("Predicting, adjusting and standardizing DunedinPACE")########################################
-  PredAgeDun <- try(PACEProjector(norm.beta, proportionOfProbesRequired=0.7), silent = TRUE)
+  suppressWarnings(PredAgeDun <- PACEProjector(norm.beta, proportionOfProbesRequired=0.7))
   paceresult <- data.frame("IID" = names(PredAgeDun[['DunedinPACE']]), "PredAge" = PredAgeDun[['DunedinPACE']])
   
   if (inherits(paceresult, 'data.frame') & inherits(paceresult$PredAge, 'numeric')) {


### PR DESCRIPTION
This pull request fix the bug for #14  where the error message has been muted.
This is not an breaking change.

The original code is in line 357 dnamage.R
```
PredAgeDun <- try(PACEProjector(norm.beta, proportionOfProbesRequired=0.7), silent = TRUE)
```
The new code is in line 358 in dnamage.R
```
suppressWarnings(PredAgeDun <- PACEProjector(norm.beta, proportionOfProbesRequired=0.7))
```