### PR TITLE
remove chr-set 23 flag

### DIFF
--- a/02a-snp_data.sh
+++ b/02a-snp_data.sh
@@ -42,7 +42,9 @@ then
 			--mind ${snp_imiss} \
 			--make-bed \
 			--out ${bfile} \
-			--allow-extra-chr --chr-set 23 \
+			--allow-extra-chr \
+			--human \
+			--output-chr 26 \
 			--chr 1-23 \
 			--threads ${nthreads}
 else
@@ -56,7 +58,9 @@ else
 		--mind ${snp_imiss} \
 		--make-bed \
 		--out ${bfile} \
-		--allow-extra-chr --chr-set 23 \
+		--allow-extra-chr \
+		--human \
+		--output-chr 26 \
 		--chr 1-23 \
 		--threads ${nthreads}
 fi

--- a/02b-convert_snp_format.sh
+++ b/02b-convert_snp_format.sh
@@ -50,7 +50,8 @@ function make_tab_format {
 echo "Converting plink files to transposed raw format"
 ${plink2} \
 	--bfile ${bfile} \
-	--allow-extra-chr --chr-set 23 \
+	--allow-extra-chr \
+	--human \
 	--recode A-transpose \
 	--out ${bfile} \
 	--freq \

--- a/03g-perform_positive_control.sh
+++ b/03g-perform_positive_control.sh
@@ -45,7 +45,9 @@ ${plink2} \
 	--bfile ${bfile} \
 	--pheno ${untransformed_methylation_adjusted}.positive_control.plink \
 	--glm allow-no-covars \
-	--allow-extra-chr --chr-set 23 \
+	--allow-extra-chr \
+	--human \
+	--output-chr 26 \
 	--out ${section_03_dir}/positive_control_untransformed_${positive_control_cpg}
 
 tr -s " " < ${section_03_dir}/positive_control_untransformed_${positive_control_cpg}.PHENO1.glm.linear | gzip -c > ${section_03_dir}/positive_control_untransformed_${positive_control_cpg}.PHENO1.glm.linear.gz
@@ -72,7 +74,7 @@ ${plink2} \
 	--bfile ${bfile} \
 	--pheno ${transformed_methylation_adjusted}.positive_control.plink \
 	--glm allow-no-covars \
-	--allow-extra-chr --chr-set 23 \
+	--allow-extra-chr \
 	--out ${section_03_dir}/positive_control_transformed_${positive_control_cpg}
 
 tr -s " " < ${section_03_dir}/positive_control_transformed_${positive_control_cpg}.PHENO1.glm.linear | gzip -c > ${section_03_dir}/positive_control_transformed_${positive_control_cpg}.PHENO1.glm.linear.gz


### PR DESCRIPTION
correct the use of --chr-set 23 flag

make sure the chr X has been covnert into che 23 in the bim file in 02a, 02b and 03g script.

please let me know if other scripts need to do the convertion.

please let the analyst know if they need to rerun the scripts.