### PR TITLE
change genetic_chunk in config example file

### DIFF
--- a/config.example
+++ b/config.example
@@ -71,7 +71,7 @@ nthreads="16"
 meth_chunks="100"
 
 # Number of chunks to split genetic data during mQTL and cellcount GWAS
-# See 03d, 06a, 06b and 07e
+# See 06a, 06b and 07e
 genetic_chunks="100"
 
 # Number of chunks to split genetic data during inversion calling

--- a/config.example
+++ b/config.example
@@ -72,7 +72,7 @@ meth_chunks="100"
 
 # Number of chunks to split genetic data during mQTL and cellcount GWAS
 # See 03d, 06a, 06b and 07e
-genetic_chunks="1000"
+genetic_chunks="100"
 
 # Number of chunks to split genetic data during inversion calling
 # See 08a


### PR DESCRIPTION
I modified the number of genetic_chunks from 1000 to 100. I tested the EPIC data in 100 chunks before it worked well.

I wonder if running 1000 jobs in parallel is too infeasible or time-consuming for some cohorts, so they did not upload any results after getting mQTLs.

genetic_chunks is only used in module 07 in my mind, so this change won't impact other modules.