### PR TITLE
83 one pc left

### DIFF
--- a/config.example
+++ b/config.example
@@ -71,7 +71,7 @@ nthreads="16"
 meth_chunks="100"
 
 # Number of chunks to split genetic data during mQTL and cellcount GWAS
-# See 03d, 06a, 06b and 07e
+# See 06a, 06b and 07e
 genetic_chunks="100"
 
 # Number of chunks to split genetic data during inversion calling

--- a/config.example
+++ b/config.example
@@ -71,8 +71,8 @@ nthreads="16"
 meth_chunks="100"
 
 # Number of chunks to split genetic data during mQTL and cellcount GWAS
-# See 06a, 06b and 07e
-genetic_chunks="100"
+# See 03d, 06a, 06b and 07e
+genetic_chunks="1000"
 
 # Number of chunks to split genetic data during inversion calling
 # See 08a

--- a/config.example
+++ b/config.example
@@ -72,7 +72,7 @@ meth_chunks="100"
 
 # Number of chunks to split genetic data during mQTL and cellcount GWAS
 # See 03d, 06a, 06b and 07e
-genetic_chunks="1000"
+genetic_chunks="100"
 
 # Number of chunks to split genetic data during inversion calling
 # See 08a

--- a/resources/logs/check_results.sh
+++ b/resources/logs/check_results.sh
@@ -153,46 +153,9 @@ check_results_03a () {
 
 }
 
-check_results_03d () {
-
-	check_results_03a
-
-	if [ -f "${home_directory}/processed_data/methylation_data/meth_pcs_transformed.txt" ]; then
-		echo "meth_pcs_transformed.txt present"
-	else
-		echo "meth_pcs_transformed.txt absent. Please re-run 3c."
-		exit 1
-	fi
- 	
-	if [ -f "${home_directory}/processed_data/methylation_data/meth_pcs_untransformed.txt" ]; then
-		echo "meth_pcs_nongenetic_untransformed.txt present"
-	else
-		echo "methylation_data meth_pcs_untransformed.txt absent. Please re-run 3c."
-		exit 1
-	fi
-
-
-	if [ -f "${home_directory}/processed_data/methylation_data/meth_pcs_nongenetic_transformed.txt" ]; then
-		echo "meth_pcs_nongenetic_transformed.txt present"
-	else
-		echo "meth_pcs_nongenetic_transformed.txt absent. Please re-run 3d."
-		exit 1
-	fi
- 	
-	if [ -f "${home_directory}/processed_data/methylation_data/meth_pcs_nongenetic_untransformed.txt" ]; then
-		echo "meth_pcs_nongenetic_untransformed.txt present"
-	else
-		echo "meth_pcs_nongenetic_untransformed.txt absent. Please re-run 3d."
-		exit 1
-	fi
-	
-}
-
 check_results_03 () {
 
 	check_results_03a
-
-  	check_results_03d
 
  	if [ -f "${section_03_dir}/positive_control_transformed_${positive_control_cpg}.PHENO1.glm.linear.gz" ]; then
 		echo "transformed mQTL analysis positive control results present"


### PR DESCRIPTION
I deleted 03d file check - Following the previous modification, when there is no methylation PC left, no non-genetic PC file will be generated.

Related issue https://github.com/genetics-of-dna-methylation-consortium/godmc_phase2/issues/83

There are changes history about config file in this branch, it is because I thought genetic_chunk variable is only used in module 06/07. To speed up the module 07, I changed it to 100. However, it was also used in 02, so I deleted the modification. I made all these modifications in github website because the maintanance of our server, so the whole history was listed here.