### PR TITLE
split snps to chunks to avoid OOM

### DIFF
--- a/06a-process_input_data.sh
+++ b/06a-process_input_data.sh
@@ -76,11 +76,23 @@ fi
 echo "Generate genotype data with pruned SNPs"
 for c in $(seq 1 22);
 do
+    lines=$(( ($(wc -l < ${scripts_directory}/resources/genetics/pruned_snps_vmeQTL_phase2_chr${c}) + ${prune_sub} - 1) / ${prune_sub} ))
+    split -l "$lines" ${scripts_directory}/resources/genetics/pruned_snps_vmeQTL_phase2_chr${c} _tmp_subfile_ && \
+    i=1 && for f in _tmp_subfile_*; do mv "$f" "${scripts_directory}/resources/genetics/pruned_snps_vmeQTL_phase2_chr${c}_sub$i"; ((i++)); done
     ${plink} \
         --bfile ${bfile} \
         --extract ${scripts_directory}/resources/genetics/pruned_snps_vmeQTL_phase2_chr${c} \
         --make-bed \
         --out ${tabfile}.prunedSNPs.chr${c}
+
+    for chunk in $(seq 1 ${prune_sub});
+	do
+	${plink} \
+        --bfile ${tabfile}.prunedSNPs.chr${c} \
+        --extract ${scripts_directory}/resources/genetics/pruned_snps_vmeQTL_phase2_chr${c}_sub${chunk} \
+        --make-bed \
+        --out ${tabfile}.prunedSNPs.chr${c}.chunk${chunk}
+	done
 done
 
 echo "Generate the genotype data of previously identified vQTLs"

--- a/06g-interaction_trans_candidateCpGs.sh
+++ b/06g-interaction_trans_candidateCpGs.sh
@@ -6,26 +6,27 @@ set -- $concatenated
 mkdir -p ${section_06_dir}/logs_g
 mkdir -p ${section_06_dir}/GEI_trans/candidate_CpGs
 
-exec &> >(tee ${section_06g_logfile}_chr${1})
+exec &> >(tee ${section_06g_logfile}_chr${1}_chunk${2})
 print_version
 
 chr=$1
-mkdir -p ${section_06_dir}/GEI_trans/candidate_CpGs/snp_chr${chr}
+chunk=$2
+mkdir -p ${section_06_dir}/GEI_trans/candidate_CpGs/snp_chr${chr}/chunk${chunk}
 
 echo "Start to run 06g chr ${chr} at $(date)"
 python ${scripts_directory}/resources/methylation/interaction_trans.py \
-    ${tabfile}.prunedSNPs.chr${chr} \
+    ${tabfile}.prunedSNPs.chr${chr}.chunk${chunk} \
     ${meth_vmeQTL_directory}/vmeQTL_phase2/adjustcovs_cpg_phase2_cpg_of_interest.bed.gz \
     ${envs_input} \
-    ${section_06_dir}/GEI_trans/candidate_CpGs/snp_chr${chr}/chr${chr} \
+    ${section_06_dir}/GEI_trans/candidate_CpGs/snp_chr${chr}/chunk${chunk}/chr${chr}_chunk${chunk} \
     0 \
     0.05
 
-${R_directory}Rscript ${scripts_directory}/resources/methylation/filter_GEI.R ${section_06_dir}/GEI_trans/candidate_CpGs/snp_chr${chr}
+${R_directory}Rscript ${scripts_directory}/resources/methylation/filter_GEI.R ${section_06_dir}/GEI_trans/candidate_CpGs/snp_chr${chr}/chunk${chunk}
 
-if [ -f ${section_06_dir}/GEI_trans/candidate_CpGs/snp_chr${chr}/GEI_geneticPC_interaction_5e-8.csv ];
+if [ -f ${section_06_dir}/GEI_trans/candidate_CpGs/snp_chr${chr}/chunk${chunk}/GEI_geneticPC_interaction_5e-8.csv ];
 then
-    rm ${section_06_dir}/GEI_trans/candidate_CpGs/snp_chr${chr}/*genetic_pc*parquet
+    rm ${section_06_dir}/GEI_trans/candidate_CpGs/snp_chr${chr}/chunk${chunk}/*genetic_pc*parquet
 fi
 
-echo "06g chr ${chr} has been done successfully at $(date)"
+echo "06g chr ${chr} chunk ${chunk} has been done successfully at $(date)"

--- a/submission_scripts_template/godmc_06g_template.sh
+++ b/submission_scripts_template/godmc_06g_template.sh
@@ -3,7 +3,10 @@
 cd ..
 source ./config
 
-for i in $(seq 1 22);
+for i in $(seq 1 9);
 do 
-    sbatch --mem 128G ${scripts_directory}/06g-interaction_trans_candidateCpGs.sh $i
+    for chunk in $(seq 1 ${prune_sub});
+    do
+        sbatch -p interruptible_cpu,cpu --mem 128G ${scripts_directory}/06g-interaction_trans_candidateCpGs.sh $i ${chunk}
+    done
 done


### PR DESCRIPTION
The previous script to run 06g would cause OOM issue when the sample size is large. Modifications were made to split SNPs into chunks to solve this issue