### PR TITLE
Update 13a-gwas_MZepi.sh

### DIFF
--- a/13a-gwas_MZepi.sh
+++ b/13a-gwas_MZepi.sh
@@ -12,7 +12,7 @@ print_version
 # Step 1: compute epigenetic scores
 
 
-
+cut -d' ' -f1-12 "${pca}.eigenvec" > ${pca}_10.eigenvec
 
 ${R_directory}Rscript resources/MZtwin/MZEpiScore.R \
     ${betas} \
@@ -24,7 +24,7 @@ ${R_directory}Rscript resources/MZtwin/MZEpiScore.R \
 
 echo "Finished computing Epi-MZ scores"
 
-cut -d' ' -f1-12 "${pca}.eigenvec" > ${pca}_10.eigenvec
+
 
 # Step 2: generate a sparse genetic relationship matrix (GRM) and PCA ###################################
 # For family data, use all samples, correcting for the full (sparse) GRM.

--- a/resources/MZtwin/MZEpiScore.R
+++ b/resources/MZtwin/MZEpiScore.R
@@ -31,7 +31,7 @@ pc_file =arguments[6]
 #############################################################################################################################################################################################################################
 # Prepare covariates files for GWAS 
 #############################################################################################################################################################################################################################
-covariates <- read.table(paste0(covariates_dir,"/covariates_intersectids.txt"),header=T)
+covariates <- read.table(paste0(covariates_dir,"covariates_intersectids.txt"),header=T)
 
 age_index <- grep("^age_numeric$", names(covariates), ignore.case=TRUE)
   count_age <- length(unique(covariates[,age_index]))


### PR DESCRIPTION
To solve issue #169 and #171

Fixed bug that resulted in error to find PC file: The file pca_10.eigenvec was called before it had been created. I have now moved up the line that creates the file pca_10.eigenvec in 13a-gwas_MZepi.sh.

In addition, I removed a redundant "/" from resources/MZEpiScore.R (which only throwed an error in combination with the missing pca_10.eigenve file). 

